### PR TITLE
fix(ci): update Rust toolchain to 1.89.0 for edition 2024 compatibility

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.88.0
+          toolchain: 1.89.0
           components: rustfmt,clippy
 
       - name: Show Rust toolchain


### PR DESCRIPTION
fix(ci): update Rust toolchain to 1.89.0 for edition 2024 compatibility (#2)

This PR updates the Rust toolchain to version 1.89.0 in the CI workflow to support `edition = "2024"` in `Cargo.toml` and resolve compatibility issues with newer Rust features and lints, including `mismatched_lifetime_syntaxes`. It also ensures `rustfmt` and `clippy` are available for `just fmt` and `just clippy` steps.

### Changes
- Added `dtolnay/rust-toolchain@stable` with `toolchain: 1.89.0` and `components: rustfmt,clippy` in `.github/workflows/pull_request.yml`.

### Related Issues
- Fixes failing CI in PRs due to `edition = "2024"` incompatibility with older Rust versions.